### PR TITLE
Added restoration of set state on startup, without using Qt.

### DIFF
--- a/pychronos/sensors/lux1310.py
+++ b/pychronos/sensors/lux1310.py
@@ -114,6 +114,8 @@ class lux1310(api):
         self.adcOffsets = [0] * self.HRES_INCREMENT
 
         self.__nTrigFrames = 5
+        self.integrationTime = 0
+        
         super().__init__()
 
     def writeDAC(self, dac, voltage):


### PR DESCRIPTION
	- State is only saved for restoration after it's been successfully
	  applied. This should help prevent the camera from getting stuck.
	- Restoration currently seems to happen before something is ready.
	  Is this restoration's fault or the fault of the thing? It does
	  mean some state gets restored and then overwritten later.
	- Not all camera properties are saved. Decorate properties to be
	  saved with `@camProperty('save')`.
	- This commit also implements availableKeys properties, which were
	  dummied out to be always true.