### PR TITLE
Added import and export functions for lux2100 column gain cal.

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ API to the `chronos-cli` program.
 |`powerOnWhenMainsConnected`                 |`G`|`S`|`N`| bool   | False | True  | Set to `True` to have the camera turn itself on when it is plugged in.
 |`powerOffWhenMainsLost`                     |`G`|`S`|`N`| bool   | False | True  | Set to `True` to have the camera turn itself off when mains power is disconnected.
 |`backlightEnabled`                          |`x`|`x`|`x`| bool   |       |       | True if the LCD on the back of the camera is lit. Can be set to False to dim the screen and save a small amount of power.
-|`fanOverride`                               |`G`|`S`|`N`| bool   | False | True  | Set to `True` to turn the fan off if it is safe to do so, or set to `False` to let the camera control the fan speed.
+|`fanOverride`                               |`G`|`S`|`N`| float  | -1.0  | 1.0   | Override the fan speed with a value in the range of 0.0=off and 1.0=full. Negative values (default) enable automatic fan control based on temperature.
 
 ### Camera Network Parameters
 | Parameter         | G | S | N | Type   | Min   | Max   | Description

--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ of the supported methods are as follows:
 | `softTrigger`               |`S`| none             |              | Generate a software trigger event.
 | `revertToDefaults`          |   | none             |              | Revert all settings to their default values (with optional parameter overrides).
 | `softReset`                 |`S`| none             | `reset`      | Perform a soft reset and initialization of the FPGA and image sensor.
+| `reboot`                    |`S`| dict(parameters) | `reset`      | Perform a reboot of the camera, API or return to factory default settings.
 | `getResolutionTimingLimits` |`S`| dict(resolution) |              | Test if a resolution is valid and return the timing limits (framerate) at that resolution. Example: `call --system --dest ca.krontech.chronos.control --object-path /ca/krontech/chronos/control --method ca.krontech.chronos.control.getResolutionTimingLimits "{'hRes': <1280>, 'vRes': <1020>}"` → `({'minFramePeriod': <931277>, 'exposureMin': <1000>, 'cameraMaxFrames': <17542>, 'exposureMax': <925722>},)`. Maximum framerate is `1e9 / minFramePeriod`.
 
 All methods return a dictionary of parameters, normally this will just include

--- a/camControl/__init__.py
+++ b/camControl/__init__.py
@@ -1,0 +1,1 @@
+from camControl.api import controlApi

--- a/camControl/__main__.py
+++ b/camControl/__main__.py
@@ -1,0 +1,112 @@
+#!/usr/bin/python3
+
+import os, sys, pdb
+import signal
+import json
+import argparse
+
+import inspect
+import logging
+import traceback
+import time
+
+import dbus
+import dbus.service
+import dbus.mainloop.glib
+from gi.repository import GLib
+
+from pychronos import camera
+from pychronos.error import *
+
+from pychronos.utils import getBoardRevision
+
+from camControl import controlApi
+
+class cameraTimer:
+    def __init__(self, camera):
+        self.camera = camera
+
+    def __call__(self, *args):
+        self.camera.tick()
+        return True
+
+def main():
+    # Enable logging.
+    logging.basicConfig(level=logging.DEBUG, format='%(asctime)s %(levelname)s [%(funcName)s] %(message)s')
+
+    # Default sensors to use by top byte of board revision.
+    sensorRevLookup = {
+        '00': 'lux1310',    # Chronos 1.4 original hardware.
+        '14': 'lux1310',    # Chronos 1.4 new production.
+        '21': 'lux2100'     # Chronso 2.1
+    }
+
+    # Do argument parsing
+    parser = argparse.ArgumentParser(description="Chronos control daemon")
+    parser.add_argument('--sensor', metavar='NAME', action='store',
+                        default=sensorRevLookup.get(getBoardRevision()[0:2], 'lux1310'),
+                        help="Override the image sensor driver to use")
+    parser.add_argument('--config', metavar='FILE', action='store',
+                        default='/var/camera/apiConfig.json',
+                        help="Configuration file path")
+    parser.add_argument('--debug', default=False, action='store_true',
+                        help="Enable debug logging")
+    parser.add_argument('--pdb', default=False, action='store_true',
+                        help="Drop into a python debug console on exception")
+    args = parser.parse_args()
+
+    if not args.debug:
+        logging.getLogger().setLevel(logging.INFO)
+    else:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    # Install exception handlers for interactive debug on exception.
+    if args.pdb:
+        def excepthook(t,v,tb):
+            pdb.traceback.print_exception(t, v, tb)
+            pdb.post_mortem(t=tb)
+        sys.excepthook = excepthook
+        dbg, brk = pdb.set_trace, pdb.set_trace #convenience debugging
+
+        #Fix system not echoing keystrokes in debugger, after restart.
+        try:
+            os.system('stty sane')
+        except Exception:
+            pass
+
+    # Use the GLib mainloop.
+    dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+    mainloop = GLib.MainLoop()
+
+    # Import the desired sensor class.
+    sensorModule = __import__("pychronos.sensors", globals(), None, fromlist=[args.sensor])
+    sensorClass = sensorModule.__getattribute__(args.sensor)
+
+    # Create the camera and objects.
+    sensor = sensorClass()
+    cam  = camera(sensor)
+
+    # Install a timer for battery data monitoring
+    timer = cameraTimer(cam)
+    GLib.timeout_add(1000, timer)
+
+    bus = dbus.SystemBus()
+    name = dbus.service.BusName('ca.krontech.chronos.control', bus=bus)
+    obj  = controlApi(bus, '/ca/krontech/chronos/control', mainloop, cam, configFile=args.config)
+
+    # Run the mainloop.
+    logging.info("Running control service...")
+    mainloop.run()
+
+    # Handle reboot
+    logging.info("Stopping control service... %s", obj.rebootMode)
+    if obj.rebootMode.get('settings', False):
+        os.remove(args.config)
+
+    if obj.rebootMode.get('power', False):
+        os.system("shutdown -hr now")
+    elif obj.rebootMode.get('reload', True):
+        os.kill(os.getpid(), signal.SIGHUP)
+
+if __name__ == "__main__":
+    main()

--- a/camControl/api.py
+++ b/camControl/api.py
@@ -535,6 +535,35 @@ class controlApi(dbus.service.Object):
             }
     
     #===============================================================================================
+    #Method('exportCalData', arguments='a{sv}', returns='a{sv}'),
+    @dbus.service.method(interface, in_signature='a{sv}', out_signature='a{sv}')
+    def exportCalData(self, args):
+        """Export flat-field frames in numpy format to USB thumb drive."""
+        try:
+            self.runGenerator(self.camera.exportCalData(**args))
+            return {
+                "state": self.camera.state
+            }
+        except CameraError as e:
+            return {
+                "state": self.camera.state,
+                "error": str(e)
+            }
+
+    @dbus.service.method(interface, in_signature='a{sv}', out_signature='a{sv}')
+    def importCalData(self, args):
+        """ Import calibration data that was generated off-camera. """
+        try:
+            self.camera.importCalData(**args)
+            return {
+                "state": self.camera.state
+            }
+        except CameraError as e:
+            return {
+                "state": self.camera.state,
+                "error": str(e)
+            }
+    #===============================================================================================
     #Method('startAutoWhiteBalance', arguments='a{sv}', returns='a{sv}'),
     #Method('revertAutoWhiteBalance', arguments='a{sv}', regutns='a{sv}'),
     #Method('startRecording', arguments='', regutns='a{sv}'),

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,36 @@
-pychronos (0.4.0~alpha113) unstable; urgency=medium
+pychronos (0.4.0~alpha144) unstable; urgency=medium
 
+  * Convert cam_control to a python module.
+  * Change fanOverride to a float, to set speed directly.
+  * Fix reboot logic when reverting settings.
+  * Add reboot() call to the API.
+  * lux2100: Workaround for PRSTN in standard timing program.
+  * lux2100: Always set mono binning mode.
+  * Fix suffix logic in startFilesave() API call.
+  * Support temperature readings from LM73 sensors.
+  * Fix int/float conversion errors in resolution parsing.
+  * timing: Adjust register map based on version.
+  * sensor: getExposureRange should be relative to minFrameTime
+  * lux2100: Added additonal gain reg write for v2 sensors.
+  * Set wbTemperature to 0K aftter auto white balance.
+  * Fix typo in IO debounce config.
+  * Fix watch-computer using old, unset variable $CHRONOS_PASSWORD.
+  * Add wrappers for the legacy IO prarameters.
+  * Add missing ioMappingGate to the IO block.
+  * Fix variant/type errors on get to the video system.
+  * Add board detection (1.4 vs. 2.1) and model name generation.
+  * Fix typos and add IO parameter sorting priority.
+  * ioInterface: Fix string case matching bug.
+  * Implement backlightEnabled to be able to turn off the screen.
+  * More reorganization and documentation of the IO block.
+  * Fix bug causing fan override to always read as true.
+  * Move API parameters for IO into a separate class.
+  * Refactor power properties, add battery critical tracking.
+  * Add sensorTemperature parameter
+  * lux2100: Fixup ADC calibration errors.
+  * Add clearCalibration method to erase calibration data.
+  * Fix typo left in for error debugging.
+  * Improvements to video API parameter proxy.
   * Add package and service dependency on chronos-pwrutil
   * Update debian scripts for automated package builds.
   * Remove conflict dependency with chronos-gui package.
@@ -117,4 +148,4 @@ pychronos (0.4.0~alpha113) unstable; urgency=medium
   * Add version.py to maintain a single API version number.
   * Upstream release v0.4.0-alpha
 
- -- Owen Kirby <oskirby@gmail.com>  Fri, 15 Nov 2019 17:32:10 -0800
+ -- Owen Kirby <oskirby@gmail.com>  Fri, 17 Jan 2020 13:50:32 -0800

--- a/debian/chronos-control.install
+++ b/debian/chronos-control.install
@@ -1,2 +1,0 @@
-#!/usr/bin/dh-exec
-cam_control.py => usr/bin/cam_control

--- a/debian/chronos-control.service
+++ b/debian/chronos-control.service
@@ -7,6 +7,7 @@ Requires=chronos-fpga.service chronos-pwrutil.service
 Type=dbus
 ExecStart=/usr/bin/cam_control
 BusName=ca.krontech.chronos.control
+RestartForceExitStatus=SIGHUP
 StandardOutput=journal+console
 StandardError=inherit
 

--- a/debian/chronos-control.service
+++ b/debian/chronos-control.service
@@ -5,7 +5,7 @@ Requires=chronos-fpga.service chronos-pwrutil.service
 
 [Service]
 Type=dbus
-ExecStart=/usr/bin/cam_control
+ExecStart=/usr/bin/camControl
 BusName=ca.krontech.chronos.control
 RestartForceExitStatus=SIGHUP
 StandardOutput=journal+console

--- a/pychronos/camera.py
+++ b/pychronos/camera.py
@@ -762,6 +762,17 @@ class camera:
                 os.rmdir(os.path.join(root, name))
                 logging.debug("DIR: %s", os.path.join(root, name))
 
+    def exportCalData(self):
+        try:
+            yield from self.sensor.startFlatFieldExport()
+        except Exception as e:
+            self.__setState('idle')
+            raise e
+        self.__setState('idle')
+
+    def importCalData(self):
+        self.sensor.importColGains()
+
     #===============================================================================================
     # API Parameters: Configuration Dictionary
     @camProperty()

--- a/pychronos/power.py
+++ b/pychronos/power.py
@@ -185,20 +185,23 @@ class power:
     
     @camProperty(notify=True, save=True)
     def fanOverride(self):
-        """bool: Set to `True` to manually disable the fan."""
-        return (self.cache.fanOverride != "auto")
+        """float: Fan speed in the range of 0=off to 1.0=full, or -1 for automatic fan control."""
+        return -1.0 if (self.cache.fanOverride < 0) else (self.cache.fanOverride / 255.0)
     
     @fanOverride.setter
     def fanOverride(self, value):
-        if (value):
-            self.cache.fanOverride = 0
-            self.sendMessage('SET_FAN_OFF')
-        else:
-            self.cache.fanOverride = "auto"
+        if (value < 0):
+            self.cache.fanOverride = -1
             self.sendMessage('SET_FAN_AUTO')
+        elif (value >= 1.0):
+            self.cache.fanOverride = 255
+            self.sendMessage('SET_FAN_255')
+        else:
+            self.cache.fanOverride = int(value * 255)
+            self.sendMessage('SET_FAN_%d' % (self.cache.fanOverride))
         self.__propChange("fanOverride")
 
-    @camProperty(notify=True, save=True)
+    @camProperty(notify=True)
     def powerOnWhenMainsConnected(self):
         """bool: Set to `True` to have the camera turn itself on when it is plugged into mains power."""
         return bool(self.cache.powerMode & 1)
@@ -211,7 +214,7 @@ class power:
             self.setPowerMode(self.cache.powerMode & ~1)
         self.__propChange("powerOnWhenMainsConnected")
     
-    @camProperty(notify=True, save=True)
+    @camProperty(notify=True)
     def powerOffWhenMainsLost(self):
         """bool: Set to `True` to have the camera turn itself off when it is unplugged from mains power."""
         return bool(self.cache.powerMode & 2)

--- a/pychronos/sensors/api.py
+++ b/pychronos/sensors/api.py
@@ -462,3 +462,36 @@ class api(ABC):
     def getCurrentGain(self, gain):
         """Return the current analog gain of the image sensor"""
         pass 
+
+    @abstractmethod
+    def exportCalData(self, saveLocation=None):
+        """Export flat-fields while in ADC test mode for PC based calibration
+
+        Args:
+            saveLocation (string): Filesystem path to a directory that can
+                be transferred to an external PC for processing.
+
+        Returns:
+            bool: `True` if the flat-fields were successfully captured and
+                saved. `False` if the capture or saving failed.
+        """
+        pass
+
+    @abstractmethod
+    def importColGains(self, sourceLocation='/media/sda1', calLocation='/var/camera/cal'):
+        """Import column gain calibration data (.bin files) that were generated off-camera
+        
+        Args:
+            sourceLocation (string, optional): Filesystem path to the location of the .bin
+                calibration files that were generated off-camera. Defaults to a usb thumb
+                drive on /media/sda1.
+
+            calLocation (string, optional): Filesystem path to the directory where
+                user calibration data is stored. Defaults to /var/camera/cal.
+
+        Returns:
+            bool: `True` if all calibration data files were copied for each level of
+                analog gain and wavetable. `False` if one or more files were not
+                copied.
+        """
+        pass

--- a/pychronos/sensors/api.py
+++ b/pychronos/sensors/api.py
@@ -464,16 +464,24 @@ class api(ABC):
         pass 
 
     @abstractmethod
-    def exportCalData(self, saveLocation=None):
+    def startFlatFieldExport(self, saveLocation='/media/sda1'):
         """Export flat-fields while in ADC test mode for PC based calibration
 
         Args:
-            saveLocation (string): Filesystem path to a directory that can
+            saveLocation (string, optional): Filesystem path to a directory that can
                 be transferred to an external PC for processing.
 
-        Returns:
-            bool: `True` if the flat-fields were successfully captured and
-                saved. `False` if the capture or saving failed.
+        Yields:
+            float: The sleep time, in seconds, between steps of the export procedure.
+
+        Examples:
+            This function returns a generator iterator with the sleep time between the
+            steps of the flat-field export procedure. The caller may use this for
+            cooperative multithreading, or can complete the export sychronously
+            as follows:
+
+            >>> for delay in sensor.startFlatFieldExport():
+            >>>    time.sleep(delay)
         """
         pass
 

--- a/pychronos/sensors/lux2100.py
+++ b/pychronos/sensors/lux2100.py
@@ -840,9 +840,12 @@ class lux2100(api):
         gain = int(self.getCurrentGain())
         return "%s_G%d_WT%d%s" % (prefix, gain, wtClocks, extension)
 
-    def exportCalData(self, saveLocation=None):
+    def startFlatFieldExport(self, saveLocation='/media/sda1'):
+        logging.debug('Starting flat-field export')
+
         display = pychronos.regmaps.display()
         sensor = pychronos.regmaps.sensor()
+        seq = sequencer()
         hRes = pychronos.sensors.lux2100().getMaxGeometry().hRes
         vRes = pychronos.sensors.lux2100().getMaxGeometry().vRes
 
@@ -866,7 +869,7 @@ class lux2100(api):
         for gain in range(0, len(adcTestModeVoltages)):  
             # Create a folder for each level of analog gain.
             #TOOD: replace Chronos21 with serial number string
-            gainPath = saveLocation + "%s/x%d/" % ('Chronos21', 1 << gain)
+            gainPath = saveLocation + "/%s/x%d/" % ('Chronos21', 1 << gain)
             try:
                 os.makedirs(gainPath, exist_ok=True)
                 logging.info('Saving flat fields to ' + gainPath)
@@ -890,7 +893,11 @@ class lux2100(api):
                 fAverage = numpy.zeros((vRes, hRes), dtype=numpy.uint16)
 
                 for i in range(0, numFrameSamples):
-                    fAverage += numpy.asarray(pychronos.readframe(0x4b000, hRes, vRes))
+                    yield from seq.startLiveReadout(hRes, vRes)
+                    if not seq.liveResult:
+                        logging.error("Flat field export failed to read frame.")
+                        return False
+                    fAverage += numpy.asarray(seq.liveResult)
 
                 # Save a .raw frame as a numpy array, which guarantees platform independence for the data order.
                 fName = gainPath + "%d.npy" % intensity

--- a/pychronos/sensors/lux2100.py
+++ b/pychronos/sensors/lux2100.py
@@ -7,6 +7,7 @@ import copy
 import numpy
 import logging
 import json
+import shutil
 
 from pychronos.error import *
 from pychronos.regmaps import sequencer, ioInterface
@@ -279,7 +280,7 @@ class lux2100(api):
         # Configure for nominal gain.
         self.regs.regGainSelSamp = 0x007f
         self.regs.regGainSelFb = 0x007f
-        self.regs.regGainBit = 0x03
+        self.regs.regSerialGain = 0x03
 
         # Enable ADC offset correction.
         for x in range(0, self.ADC_CHANNELS):
@@ -547,7 +548,7 @@ class lux2100(api):
         samp, feedback, sgain = gainConfig[int(gain)]
         self.regs.regGainSelSamp = samp
         self.regs.regGainSelFb = feedback
-        self.regs.regGainBit = sgain
+        self.regs.regSerialGain = sgain
 
     def getCurrentGain(self):
         gsMap = {
@@ -570,7 +571,7 @@ class lux2100(api):
             fbacknbits += (x & 1)
             x >>= 1
 
-        x = self.regs.regGainBit
+        x = self.regs.regSerialGain
         while (x != 0):
             gsernbits += (x & 1)
             x >>= 1
@@ -701,14 +702,28 @@ class lux2100(api):
             colGainData.tofile(self.calFilename(saveLocation + '/colGain', ".bin"))
         
     def loadAnalogCal(self, calLocation):
-        # Generate the calibration filename.
-        suffix = self.calFilename("/colGain", ".bin")
-        filename = calLocation + suffix
-        
         # Load calibration!
         display = pychronos.regmaps.display()
         colGainRegs = pychronos.fpgamap(pychronos.FPGA_COL_GAIN_BASE, 0x1000)
         colCurveRegs = pychronos.fpgamap(pychronos.FPGA_COL_CURVE_BASE, 0x1000)
+      
+        # Load the factory column gain calibration, using one column gain coefficient per horizontal pixel.
+        # Generate the calibration filename.
+        filename = calLocation + self.calFilename("/factory_colGain", ".bin")
+        try:
+            logging.info("Loading column gain calibration from %s", filename)
+            colGainData = numpy.fromfile(filename, dtype=numpy.int32, count=self.MAX_HRES)
+            for col in range(0, self.MAX_HRES):
+                colGainRegs.mem16[col] = int(colGainData[col])
+                colCurveRegs.mem16[col] = 0
+            display.gainControl &= ~display.GAINCTL_3POINT
+            return True   
+        except Exception as err:
+            logging.info("Couldn't load factory col gain, falling back to auto 2-point col gain.")         
+
+        # If the factory calibration file is missing, fall back to 2-point cal data, using one column gain coefficient per ADC channel.
+        # Generate the calibration filename.
+        filename = calLocation + self.calFilename("/colGain", ".bin")
         try:
             logging.info("Loading column gain calibration from %s", filename)
             colGainData = numpy.fromfile(filename, dtype=numpy.float, count=self.ADC_CHANNELS)
@@ -824,3 +839,84 @@ class lux2100(api):
         wtClocks = self.regs.regRdoutDly
         gain = int(self.getCurrentGain())
         return "%s_G%d_WT%d%s" % (prefix, gain, wtClocks, extension)
+
+    def exportCalData(self, saveLocation=None):
+        display = pychronos.regmaps.display()
+        sensor = pychronos.regmaps.sensor()
+        hRes = pychronos.sensors.lux2100().getMaxGeometry().hRes
+        vRes = pychronos.sensors.lux2100().getMaxGeometry().vRes
+
+        gainSampCap =   [0x007F, 0x01FF, 0x0FFF, 0x0FFF, 0x0FFF]
+        gainSerFbCap =  [0x037F, 0x030F, 0x011F, 0x001F, 0x000F]
+
+        adcTestModeVoltages = [
+            [0x2D, 0x2E, 0x2F, 0x30, 0x31, 0x32, 0x33, 0x34],   #x1, 0 dB
+            [0x2D, 0x2E, 0x2F, 0x30, 0x31],                     #x2, 6 dB
+            [0x2D, 0x2E, 0x2F, 0x30],                           #x4, 12 dB
+            [0x2D, 0x2E, 0x2F],                                 #x8, 18 dB
+            [0x2D, 0x2E, 0x2F]                                  #x16,24 dB
+        ]
+
+        # Disable certain FPGA overlays to get raw sensor values.
+        display.pipeline |= display.BYPASS_GAIN | display.BYPASS_GAMMA_TABLE | display.BYPASS_DEMOSAIC
+
+        # Enter test mode.
+        self.regs.regPoutsel = 1
+
+        for gain in range(0, len(adcTestModeVoltages)):  
+            # Create a folder for each level of analog gain.
+            #TOOD: replace Chronos21 with serial number string
+            gainPath = saveLocation + "%s/x%d/" % ('Chronos21', 1 << gain)
+            try:
+                os.makedirs(gainPath, exist_ok=True)
+                logging.info('Saving flat fields to ' + gainPath)
+            except OSError as err:
+                logging.error("Could not create per-gain folders while exporting cal data.")
+                return False
+
+            # Set analog gain value
+            self.regs.regGainSelSamp = gainSampCap[gain]
+            self.regs.regGainSelFb = gainSerFbCap[gain]
+
+            # Iterate and collect flat-fields at each level of ADC test voltage step.
+            for intensity in range(0, len(adcTestModeVoltages[gain])):
+
+                # Inject a test voltage into the ADCs, see lux2100 datasheet p.30.
+                testVoltage = (adcTestModeVoltages[gain][intensity] << 8) + 0x00FF
+                sensor.sciWrite(0x67, testVoltage)
+
+                # Get the average of 3 frames.
+                numFrameSamples = 3
+                fAverage = numpy.zeros((vRes, hRes), dtype=numpy.uint16)
+
+                for i in range(0, numFrameSamples):
+                    fAverage += numpy.asarray(pychronos.readframe(0x4b000, hRes, vRes))
+
+                # Save a .raw frame as a numpy array, which guarantees platform independence for the data order.
+                fName = gainPath + "%d.npy" % intensity
+                outFrame = numpy.array(fAverage / numFrameSamples, dtype=numpy.uint16)
+                numpy.save(fName, outFrame)
+
+        return True
+
+    def importColGains(self, sourceLocation='/media/sda1', calLocation='/var/camera/cal'):
+        # Copy column gain calibration data into camera.
+        gainLvls = [1, 2, 4, 8, 16]
+        wtClocks = [66, 45, 35, 25]
+        copyCount = 0
+
+        for wt in range(0, len(wtClocks)):
+            for gain in range(0, len(gainLvls)):
+                #Build filename string
+                fName = 'factory_colGain_G%d_WT%d.bin' % (gainLvls[gain], wtClocks[wt])
+                try:
+                    shutil.copy(os.path.join(sourceLocation, fName), os.path.join(calLocation, fName))
+                    logging.info("Copied %s from %s to %s", fName, sourceLocation, calLocation)
+                    copyCount += 1
+                except OSError as err:
+                    logging.error("Could not copy %s from %s to %s", fName, sourceLocation, calLocation)
+
+        if (copyCount == len(gainLvls) * len(wtClocks)):
+            return True
+        else:
+            return False

--- a/pychronos/sensors/lux2100.py
+++ b/pychronos/sensors/lux2100.py
@@ -50,7 +50,7 @@ class lux2100(api):
     LUX2100_MIN_HBLANK = 2
     LUX2100_SENSOR_HZ = 75000000
     ADC_CHANNELS = 32
-    ADC_FOOTROOM = 32
+    ADC_FOOTROOM = 64
     ADC_OFFSET_MIN = -1023
     ADC_OFFSET_MAX = 1023
 
@@ -247,7 +247,7 @@ class lux2100(api):
 
         # Setup for 66-clock wavetable and 1080p with binning.
         self.regs.regRdoutDly = 66
-        self.regs.regMono = False
+        self.regs.regMono = True
         self.regs.regRow2En = True
         self.regs.regColbin2 = True
         self.regs.regPoutsel = 2

--- a/pychronos/sensors/lux2100regs.py
+++ b/pychronos/sensors/lux2100regs.py
@@ -136,7 +136,7 @@ class lux2100regs(sensor):
     regOsTarget =       __dataprop(0x0D, 0x0fff, "Dark value target for ADC offset calibration")
     regAdcOsEn =        __dataprop(0x0E, 0x0001, "Enables applying ADC offset registers during vertical blanking")
     regAdcOsSignLow =   __dataprop(0x0F, 0xffff, "Sign for ADC offsets (low channels)")
-    regAdcOsSignHigh =  __dataprop(0x0F, 0xffff, "Sign for ADC offsets (high channels)")
+    regAdcOsSignHigh =  __dataprop(0x4F, 0xffff, "Sign for ADC offsets (high channels)")
     
     # Datapath selection register.
     @property
@@ -219,7 +219,7 @@ class lux2100regs(sensor):
                 baseoff = 0x40
                 channel -= 16
 
-            signbits = self.parent.sciRead(0x0f)
+            signbits = self.parent.sciRead(0x0f + baseoff)
             if (value < 0):
                 self.parent.sciWrite(0x0f + baseoff, signbits | (1 << channel))
                 self.parent.sciWrite(0x10 + baseoff + channel, -int(value))

--- a/pychronos/sensors/lux2100timing.py
+++ b/pychronos/sensors/lux2100timing.py
@@ -123,7 +123,6 @@ class lux2100timing(timing):
 
         self.__program          = self.PROGRAM_STANDARD
         self.__disableFrameTrig = disableFrameTrig
-        self.__disableIoDrive   = disableIoDrive
         
         # Program preamble: delay before ABN falling (t2 time)
         prog = [ self.PRSTN + t2Time ]

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
-from distutils.core import setup, Extension
+from setuptools import setup
+from distutils.core import Extension
 import sysconfig
 import platform
 
@@ -36,6 +37,13 @@ setup (name='PyChronos',
        url = 'https://github.com/krontech/pychronos',
        author = about['__author__'],
        author_email = 'oskirby@gmail.com',
-       provides=['pychronos'],
-       packages=['pychronos', 'pychronos/regmaps', 'pychronos/sensors'],
+       entry_points={
+           'console_scripts': [ 'camControl=camControl.__main__:main' ]
+       },
+       packages=[
+           'camControl',
+           'pychronos',
+           'pychronos/regmaps',
+           'pychronos/sensors'
+       ],
        ext_modules = [libpychronos])


### PR DESCRIPTION
Implemented import and export functions for column gain .bin
files that will be processed off-camera. Modified loadAnalogCal
to attempt to load the new/factory processed cal files, falling
back on the 2-point auto cal if necessary. Replaced references
to regGainBit with regSerialGain, as the former seemed to be
carried over from the 1310 driver.

TODO: automate a run of black cal prior to starting export for
better frames, use the serial number as the folder name for
exporting frames.